### PR TITLE
refactor(server/frontend): add edit user info page

### DIFF
--- a/src/server/data-sources.js
+++ b/src/server/data-sources.js
@@ -21,11 +21,11 @@ class MediaDB extends SQLDataSource {
     } else index = 0;
     if (attrName == "url" || attrName == "originalUrl" || attrName == "thumbnailUrl") {
       const result = await this.knex
-      .select("random", "id", "urlFileExtension", "thumbnailFileExtension", "type", "isConverted")
-      .first()
-      .from(tableList[index])
-      .where({ id: id })
-      .cache(CACHE_TTL);
+        .select("random", "id", "urlFileExtension", "thumbnailFileExtension", "type", "isConverted")
+        .first()
+        .from(tableList[index])
+        .where({ id: id })
+        .cache(CACHE_TTL);
       if (result.isConverted) { //성공
         if (attrName == "url") {
           return `${process.env["AWS_S3URL"]}/${result.random}-${result.id}-enhanced.${result.urlFileExtension}`;
@@ -273,6 +273,10 @@ class UserDB extends SQLDataSource {
   async deactivateUser(id) {
     await this.knex("user").where({ id }).update({ isActive: false, name: "알 수 없음" });
     return true;
+  }
+
+  async updateUser(id, args) {
+    return this.knex("user").where({ id }).update(args);
   }
 }
 

--- a/src/server/resolvers/mutation.js
+++ b/src/server/resolvers/mutation.js
@@ -238,7 +238,7 @@ module.exports = {
       description,
     });
 
-   await mediaDB.modifyTagMediaConnect(tagNames, id);
+    await mediaDB.modifyTagMediaConnect(tagNames, id);
 
     return {
       id,
@@ -387,5 +387,27 @@ module.exports = {
       throw new Error("Cannot deactivate the account");
     }
     return user;
+  },
+  modifyUser: async (_, { id, name, password }, { userId, dataSources: { userDB } }) => {
+    const user = await userDB.getUser(id);
+
+    if (!userId) {
+      throw new Error("Login required");
+    }
+    if (!name) {
+      throw new Error("Name not found");
+    }
+    if (userId !== user.id) {
+      throw new Error("You are not the User of the account");
+    }
+    const hashedPassword = await bcrypt.hash(password, 3);
+    if (!(await userDB.updateUser(id, { name: name, password: hashedPassword }))) {
+      throw new Error("Cannot update the user info");
+    }
+    const token = jwt.sign({ userId: user.id }, process.env.SECRET);
+    return {
+      token,
+      user,
+    };
   },
 };

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -65,6 +65,7 @@ const typeDefs = gql`
     signUp(email: String!, password: String!, name: String!): AuthPayload!
     signIn(email: String!, password: String!): AuthPayload!
     deactivateUser(id: ID!): User!
+    modifyUser(id: ID!, password: String!, name: String): AuthPayload!
   }
 
   type AuthPayload {

--- a/src/web/src/App.js
+++ b/src/web/src/App.js
@@ -12,6 +12,7 @@ import HomePage from './pages/home-page';
 import LoginPage from './pages/login-page';
 import RegisterPage from './pages/register-page';
 import UserPage from './pages/user-page';
+import UserEditPage from './pages/user-edit-page';
 import ModifyPage from './pages/media-modify-page';
 import 'antd/dist/antd.css';
 import { setContext } from 'apollo-link-context';
@@ -70,6 +71,7 @@ function App () {
         <Route exact path="/login" render={()=> <LoginPage afterLogin={afterLogin} onChangeIsMediaView={onChangeIsMediaView}/>}/>
         <Route exact path="/register" render={()=> <RegisterPage onChangeIsMediaView={onChangeIsMediaView}/>}/>
         <Route exact path="/user" render={()=> <UserPage onChangeIsMediaView={onChangeIsMediaView}/>}/>
+        <Route exact path="/user/edit" render={()=> <UserEditPage onChangeIsMediaView={onChangeIsMediaView}/>}/>
         <Route exact path="/modify" render={()=> <ModifyPage onChangeIsMediaView={onChangeIsMediaView}/>}/>
       </Switch>
     </ApolloProvider>

--- a/src/web/src/components/SignPage/sign-page-password-confirm.js
+++ b/src/web/src/components/SignPage/sign-page-password-confirm.js
@@ -26,7 +26,7 @@ function SignPagePasswordConfirm (props) {
           }),
         ]}
       >
-        <Input.Password prefix={<LockFilled className="site-form-item-icon"/>} placeholder="비밀번호 확인"
+        <Input.Password prefix={<LockFilled/>} placeholder="비밀번호 확인"
           size="large" style={{ border: 'none', borderBottom: '1px solid #d9d9d9' }}/>
       </Form.Item>
     </div>

--- a/src/web/src/components/SignPage/sign-page-password.js
+++ b/src/web/src/components/SignPage/sign-page-password.js
@@ -16,7 +16,7 @@ function SignPagePassword (props) {
           }
           ]}
       >
-        <Input.Password prefix={<LockOutlined className="site-form-item-icon"/>} placeholder="비밀번호"
+        <Input.Password prefix={<LockOutlined/>} placeholder="비밀번호"
           onChange={props.onChangePassword} size="large" style={{ border: 'none', borderBottom: '1px solid #d9d9d9' }}/>
       </Form.Item>
     </div>

--- a/src/web/src/components/UploadPage/upload-tags-select.js
+++ b/src/web/src/components/UploadPage/upload-tags-select.js
@@ -74,7 +74,7 @@ function UploadTagsSelect (props) {
 
   // AutoComplete 의 옵션 설정: 기존에 등록되어 있는 태그에서 검색 (최대 3개)
   const handleSearch = (value) => {
-    let result = !value || !data || !!data && data.searchTag.length === 0
+    let result = !value || !data
       ? []
       : !!data && data.searchTag.slice(0, 3).map((tag) => {return {value: tag.name};});
 

--- a/src/web/src/components/UserPage/user-deactivate-button.js
+++ b/src/web/src/components/UserPage/user-deactivate-button.js
@@ -34,7 +34,7 @@ function UserDeactivateButton (props) {
 
   const handleOnClick = () => {
     Modal.confirm({
-      title: "회원 탈퇴",
+      title: "회원탈퇴",
       content: "탈퇴를 진행하시겠습니까?",
       icon: <WarningOutlined />,
       okText: 'Yes',
@@ -49,7 +49,7 @@ function UserDeactivateButton (props) {
     });
   };
   return (
-    <Button style={{ float: 'right' }} onClick={handleOnClick}>회원 탈퇴</Button>
+    <Button style={{ float: 'right' }} onClick={handleOnClick}>회원탈퇴</Button>
   );
 }
 

--- a/src/web/src/components/UserPage/user-edit-button.js
+++ b/src/web/src/components/UserPage/user-edit-button.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Button } from 'antd';
+import { UserOutlined } from '@ant-design/icons';
+import { Link } from 'react-router-dom';
+
+function UserEditButton () {
+  return (
+    <Link to={'/user/edit'}>
+      <Button style={{ float: 'right' }}><UserOutlined/>회원정보수정</Button>
+    </Link>
+  );
+}
+
+export default UserEditButton;

--- a/src/web/src/pages/user-edit-page.js
+++ b/src/web/src/pages/user-edit-page.js
@@ -1,0 +1,144 @@
+import React, { useState } from 'react';
+import { Avatar, Button, Form, Input, message } from 'antd'
+import { ColorArray } from '../components/constants';
+import { useHistory } from 'react-router-dom';
+import { LockFilled, LockOutlined } from '@ant-design/icons';
+import { useMutation } from '@apollo/react-hooks';
+import gql from 'graphql-tag';
+import UserDeactivateButton from '../components/UserPage/user-deactivate-button'
+
+const { Item } = Form;
+
+const MODIFY_USER = gql`
+    mutation ($id: ID!, $password: String!, $name: String!) {
+      modifyUser(id: $id, password: $password, name: $name) {
+        user {
+          id
+          name
+        }
+      }
+    }
+`;
+
+const formItemLayout = {
+  labelCol: { span: 3, offset: 5 },
+  wrapperCol: { span: 7, offset: 2 },
+};
+
+function UserEditPage () {
+  const [name, setName] = useState(sessionStorage.getItem('user_name'));
+  const [password, setPassword] = useState('');
+  const [mutate] = useMutation(MODIFY_USER);
+
+  const history = useHistory();
+
+  const onCancel = () => {
+    history.goBack();
+  };
+
+  const handleNameChange = (e) => {
+    setName(e.target.value);
+  };
+
+  const handlePasswordChange = (e) => {
+    setPassword(e.target.value);
+  };
+
+  const handleSubmit = () => {
+    if (name === '' || password === '') {
+      message.info('빈칸을 채워주세요.');
+    }
+    else {
+      const userId = sessionStorage.getItem('user_id');
+      mutate({ variables: { id: userId, name: name, password: password } })
+        .then(() => {
+          message.info('수정이 완료되었습니다.');
+          sessionStorage.setItem('user_name', name);
+          window.location.replace('/user');
+        })
+        .catch(() => { message.error('수정에 실패하였습니다.'); });
+    }
+  };
+
+  return (
+    <div>
+      <h2 style={{ fontSize: 25, fontWeight: 500, width: '90%', margin: '5rem auto 4rem auto' }}>
+        기본 회원 정보
+      </h2>
+      <Form {...formItemLayout} initialValues={{ name: name }}>
+        <Item label="프로필">
+          {
+            sessionStorage.getItem('user_profileImgUrl') === 'null' ?
+              <Avatar size={80}
+                style={{ backgroundColor: ColorArray[sessionStorage.getItem('user_id') % ColorArray.length] }}>
+                {sessionStorage.getItem('user_name').charAt(0)}
+              </Avatar>
+              :
+              <Avatar size={80} src={sessionStorage.getItem('user_profileImgUrl')} shape="circle"/>
+          }
+        </Item>
+        <Item label="이메일" name="email">
+          <span>{sessionStorage.getItem('user_email')}</span>
+        </Item>
+        <Item label="이름" name="name" rules={[{ required: true, message: '이름을 입력하세요.' }]}>
+          <Input onChange={handleNameChange} value={name}/>
+        </Item>
+        <Item label="비밀번호" name="password" hasFeedback
+          rules={[{ required: true, message: '비밀번호를 입력하세요.' }]}>
+          <Input.Password prefix={<LockOutlined/>} onChange={handlePasswordChange}/>
+        </Item>
+        <Item
+          label="비밀번호 확인"
+          name="confirm"
+          dependencies={['password']}
+          hasFeedback
+          rules={[
+            {
+              required: true,
+              message: '비밀번호가 일치하지 않습니다.',
+            },
+            ({ getFieldValue }) => ({
+              validator(rule, value) {
+                if (!value || getFieldValue('password') === value) {
+                  return Promise.resolve();
+                }
+
+                return Promise.reject('비밀번호가 일치하지 않습니다.');
+              },
+            }),
+          ]}>
+          <Input.Password prefix={<LockFilled/>}/>
+        </Item>
+        <Item wrapperCol={{ span: 12, offset: 10 }}>
+          <Button
+            htmlType='submit'
+            style={{
+              background: '#4a5164',
+              color: '#fff',
+              marginRight: '2%',
+              width: 105
+            }}
+            onClick={handleSubmit}
+          >
+            회원정보수정
+          </Button>
+          <Button
+            onClick={onCancel}
+            style={{
+              width: 105,
+              background: '#84868b',
+              color: '#fff'
+            }}>
+            취소
+          </Button>
+        </Item>
+      </Form>
+      {/* 회원 탈퇴 */}
+      <div style={{ width: '90%', margin: '3%', display: 'inline-block' }}>
+        <UserDeactivateButton userId={sessionStorage.getItem('user_id')}/>
+      </div>
+    </div>
+  );
+}
+
+export default UserEditPage;

--- a/src/web/src/pages/user-page.js
+++ b/src/web/src/pages/user-page.js
@@ -3,9 +3,9 @@ import { useQuery } from '@apollo/react-hooks';
 import { Avatar, Descriptions, Layout, Spin } from 'antd';
 import MediaList from '../components/Media/media-list';
 import gql from 'graphql-tag';
-import UserDeactivateButton from '../components/UserPage/user-deactivate-button';
 import { ColorArray } from '../components/constants';
 import { EditOutlined } from '@ant-design/icons';
+import UserEditButton from '../components/UserPage/user-edit-button';
 
 const MY_MEDIA = gql`
   query {
@@ -63,6 +63,10 @@ function UserPage (props) {
           </Layout.Content>
         </Layout>
       </Layout>
+      {/* 회원 정보 수정 */}
+      <div style={{ width: '90%', margin: '2% 3% 3% 3%' }}>
+        <UserEditButton/>
+      </div>
       {/* 내 게시글 */}
       <h2 style={{ fontSize: 18, fontWeight: 500, width: '90%', margin: '5rem auto 2rem auto' }}>
         <EditOutlined style={{ paddingRight: 10 }}/>내 게시글
@@ -73,10 +77,6 @@ function UserPage (props) {
           :
           <MediaList data={data.myMedia}/>
       }
-      {/* 회원 탈퇴 */}
-      <div style={{ width: '90%', margin: '3%', display: 'inline-block' }}>
-        <UserDeactivateButton userId={sessionStorage.getItem('user_id')}/>
-      </div>
     </div>
 
   );


### PR DESCRIPTION
- 회원정보수정 페이지 추가
- 이름과 비밀번호 변경 가능
- 회원 탈퇴 버튼을 회원정보수정 페이지로 옮김
- 보통 비밀번호 초기화 링크를 이메일로 보내고 바꾸는 것 같은데 여기선 그냥 교체만 한 거라서 이렇게 하는 건지 아닌지 모르겠지만 일단 반영은 잘 됨 😂

this PR closes #33 